### PR TITLE
Support DAA v2 (12-hour half-life) at block 410000; fix Python 3.12+

### DIFF
--- a/contrib/build-wine/docker/Dockerfile
+++ b/contrib/build-wine/docker/Dockerfile
@@ -18,20 +18,20 @@ RUN echo deb ${UBUNTU_MIRROR} ${UBUNTUDIST} main restricted universe multiverse 
     dpkg --add-architecture i386 && \
     apt-get update -q && \
     apt-get install -qy \
-        gnupg2=2.2.27-3ubuntu2.1 \
-        ca-certificates=20211016 \
-        wget=1.21.2-2ubuntu1 \
-        git=1:2.34.1-1ubuntu1.6 \
-        p7zip-full=16.02+dfsg-8 \
-        make=4.3-4.1build1 \
-        autotools-dev=20220109.1 \
-        autoconf=2.71-2 \
-        libtool=2.4.6-15build2 \
-        gettext=0.21-4ubuntu4 \
-        autopoint=0.21-4ubuntu4 \
-        mingw-w64=8.0.0-1 \
-        mingw-w64-tools=8.0.0-1 \
-        win-iconv-mingw-w64-dev=0.0.8-4
+        gnupg2 \
+        ca-certificates \
+        wget \
+        git \
+        p7zip-full \
+        make \
+        autotools-dev \
+        autoconf \
+        libtool \
+        gettext \
+        autopoint \
+        mingw-w64 \
+        mingw-w64-tools \
+        win-iconv-mingw-w64-dev
 
 # Official WineHQ signing key
 # See https://wiki.winehq.org/Ubuntu

--- a/electroncash/blockchain.py
+++ b/electroncash/blockchain.py
@@ -467,6 +467,7 @@ class Blockchain(util.PrintError):
 
     # cached Anchor, per-Blockchain instance, only used if the checkpoint for this network is *behind* the anchor block
     _cached_asert_anchor: Optional[asert_daa.Anchor] = None
+    _cached_asert_v2_anchor: Optional[asert_daa.Anchor] = None
 
     def get_asert_anchor(self, prevheader, mtp, chunk=None):
         """Returns the asert_anchor either from Networks.net if hardcoded or
@@ -501,6 +502,24 @@ class Blockchain(util.PrintError):
             mtp = prev_mtp
             anchor = prev
 
+    def get_asert_v2_anchor(self, chunk=None):
+        """Returns the anchor for the v2 DAA (12-hour half-life).
+        Per consensus: anchor is at (DAA_V2_HEIGHT - 1), using that block's
+        nBits and its previous block's timestamp."""
+        daa_v2 = getattr(networks.net, 'asert_daa_v2', None)
+        if daa_v2 is not None and daa_v2.anchor is not None:
+            return daa_v2.anchor
+        if self._cached_asert_v2_anchor is not None:
+            return self._cached_asert_v2_anchor
+        anchor_height = networks.net.DAA_V2_HEIGHT - 1
+        anchor_header = self.read_header(anchor_height, chunk)
+        prev_header = self.read_header(anchor_height - 1, chunk)
+        if anchor_header is None or prev_header is None:
+            self.print_error("get_asert_v2_anchor: missing headers at anchor height {}".format(anchor_height))
+            return None
+        self._cached_asert_v2_anchor = asert_daa.Anchor(anchor_height, anchor_header['bits'], prev_header['timestamp'])
+        return self._cached_asert_v2_anchor
+
     def get_bits(self, header, chunk=None):
         '''Return bits for the given height.'''
         # Difficulty adjustment interval?
@@ -526,6 +545,15 @@ class Blockchain(util.PrintError):
                 # testnet 20 minute rule
                 if header_ts - prev_ts > 20*60:
                     return MAX_BITS
+
+            # DAA v2: 12-hour half-life from DAA_V2_HEIGHT
+            daa_v2_height = getattr(networks.net, 'DAA_V2_HEIGHT', None)
+            if daa_v2_height is not None and height >= daa_v2_height:
+                anchor = self.get_asert_v2_anchor(chunk)
+                assert anchor is not None, "Failed to find ASERT v2 anchor block for chain {!r}".format(self)
+                return networks.net.asert_daa_v2.next_bits_aserti3_2d(anchor.bits,
+                                                                      prev_ts - anchor.prev_time,
+                                                                      prevheight - anchor.height)
 
             anchor = self.get_asert_anchor(prior, daa_mtp, chunk)
             assert anchor is not None, "Failed to find ASERT anchor block for chain {!r}".format(self)

--- a/electroncash/interface.py
+++ b/electroncash/interface.py
@@ -86,17 +86,32 @@ class TcpConnection(threading.Thread, util.PrintError):
         return self.host
 
     def check_host_name(self, peercert, name) -> bool:
-        """Wrapper for ssl.match_hostname that never throws. Returns True if the
-        certificate matches, False otherwise. Supports whatever wildcard certs
-        and other bells and whistles supported by ssl.match_hostname."""
-        # Check that the peer has supplied a certificate.
-        # None/{} is not acceptable.
+        """Checks that the certificate matches the hostname. Returns True if
+        the certificate matches, False otherwise."""
         if not peercert:
             return False
         try:
-            ssl.match_hostname(peercert, name)
+            # ssl.match_hostname was removed in Python 3.12;
+            # hostname verification is now handled by SSLContext.check_hostname.
+            # We still do a manual check as a fallback for pinned certs.
+            from ssl import CertificateError
+            try:
+                ssl.match_hostname(peercert, name)
+            except AttributeError:
+                # Python 3.12+: match_hostname removed, use our own check
+                san = peercert.get('subjectAltName', ())
+                dns_names = [v for k, v in san if k == 'DNS']
+                if not dns_names:
+                    # Fall back to commonName
+                    for sub in peercert.get('subject', ()):
+                        for k, v in sub:
+                            if k == 'commonName':
+                                dns_names.append(v)
+                if not any(_match_hostname(name, pat) for pat in dns_names):
+                    raise CertificateError(
+                        "hostname %r doesn't match any of %r" % (name, dns_names))
             return True
-        except ssl.CertificateError as e:
+        except (ssl.CertificateError, CertificateError) as e:
             self.print_error("SSL certificate hostname mismatch:", str(e))
         return False
 

--- a/electroncash/networks.py
+++ b/electroncash/networks.py
@@ -80,6 +80,12 @@ class MainNet(AbstractNet):
     # after the anchor must specify the anchor as well.
     asert_daa.anchor = Anchor(height=18206, bits=453224288, prev_time=1657404650)
 
+    # DAA v2: HALF_LIFE changed from 2 days to 12 hours at this height
+    DAA_V2_HEIGHT = 410000
+    asert_daa_v2 = ASERTDaa(is_testnet=False)
+    asert_daa_v2.HALF_LIFE = 12 * 3600  # 12 hours
+    asert_daa_v2.anchor = Anchor(height=409999, bits=0x1a008d39, prev_time=1773088826)
+
     # Version numbers for BIP32 extended keys
     # standard: xprv, xpub
     XPRV_HEADERS = {

--- a/electroncash/plugins.py
+++ b/electroncash/plugins.py
@@ -75,6 +75,7 @@ class Plugins(DaemonThread):
         DaemonThread.__init__(self)
         internal_plugins_namespace = __import__('electroncash_plugins')
         self.internal_plugins_pkgpath = os.path.dirname(internal_plugins_namespace.__file__)
+        self.internal_plugins_pkgname = internal_plugins_namespace.__name__
         self.config = config
         self.gui_name = gui_name
         self.hw_wallets = {}
@@ -135,7 +136,8 @@ class Plugins(DaemonThread):
             # do not load deprecated plugins
             if name in ['plot', 'exchange_rate']:
                 continue
-            m = loader.find_module(name).load_module(name)
+            import importlib
+            m = importlib.import_module(f'{self.internal_plugins_pkgname}.{name}')
             d = m.__dict__
             if not self.register_plugin(name, d):
                 continue
@@ -209,11 +211,12 @@ class Plugins(DaemonThread):
             return self.internal_plugins[name]
 
         full_name = 'electroncash_plugins.' + name + '.' + self.gui_name
-        loader = pkgutil.find_loader(full_name)
-        if not loader:
+        import importlib
+        try:
+            p = importlib.import_module(full_name)
+        except ModuleNotFoundError:
             raise RuntimeError("%s implementation for %s plugin not found"
                                % (self.gui_name, name))
-        p = loader.load_module(full_name)
         plugin = p.Plugin(self, self.config, name)
         plugin.set_enabled_prefix(INTERNAL_USE_PREFIX)
         self.add_jobs(plugin.thread_jobs())
@@ -239,19 +242,26 @@ class Plugins(DaemonThread):
             return
 
         try:
-            module = zipfile.load_module(name)
-        except zipimport.ZipImportError as e:
+            spec = zipfile.find_spec(name)
+            if spec is None:
+                raise zipimport.ZipImportError("no spec found")
+            import importlib.util
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[name] = module
+            spec.loader.exec_module(module)
+        except (zipimport.ZipImportError, Exception) as e:
             self.print_error("unable to load zip plugin '%s' package '%s'" % (plugin_file_path, name), str(e))
             return
 
         sys.modules['electroncash_external_plugins.'+ name] = module
 
         full_name = 'electroncash_external_plugins.' + name + '.' + self.gui_name
-        loader = pkgutil.find_loader(full_name)
-        if not loader:
+        import importlib
+        try:
+            p = importlib.import_module(full_name)
+        except ModuleNotFoundError:
             raise RuntimeError("%s implementation for %s plugin not found"
                                % (self.gui_name, name))
-        p = loader.load_module(full_name)
         plugin = p.Plugin(self, self.config, name)
         plugin.set_enabled_prefix(EXTERNAL_USE_PREFIX)
         self.add_jobs(plugin.thread_jobs())


### PR DESCRIPTION
…compatibility

- Add ASERT DAA v2 with 12-hour half-life activating at height 410000, with anchor at block 409999 (bits=0x1a008d39, prev_time=1773088826)
- Update get_bits() to switch DAA parameters at DAA_V2_HEIGHT
- Replace removed ssl.match_hostname for Python 3.12+ (interface.py)
- Replace deprecated find_module/load_module with importlib (plugins.py)
- Remove pinned package versions in wine build Dockerfile